### PR TITLE
Fix RedisClient raising an exception when no state has been written

### DIFF
--- a/feats/redis.py
+++ b/feats/redis.py
@@ -54,11 +54,14 @@ class FeatureStream:
         """
         return self._redis.xadd(self.key, state)
 
-    def info(self):
+    def info(self) -> dict:
         """
         Wrapper for redis xinfo
         """
-        return self._redis.xinfo_stream(self.key)
+        if self._redis.exists(self.key):
+            return self._redis.xinfo_stream(self.key)
+        else:
+            return None
 
     def read(self, index) -> dict:
         """
@@ -78,6 +81,8 @@ class FeatureStream:
         Returns the value of the latest entry in the Redis Stream (omitting id)
         """
         info = self.info()
+        if info is None:
+            return None
         return info['last-entry'][1]
 
     def first(self) -> dict:
@@ -85,7 +90,10 @@ class FeatureStream:
         Returns the value of the first entry in the Redis Stream (omitting id)
         """
         info = self.info()
+        if info is None:
+            return None
         return info['first-entry'][1]
+
 
     def __len__(self) -> int:
         """

--- a/feats/redis.py
+++ b/feats/redis.py
@@ -94,7 +94,6 @@ class FeatureStream:
             return None
         return info['first-entry'][1]
 
-
     def __len__(self) -> int:
         """
         Wrapper for stream xlen

--- a/integration_tests/redis/redis.py
+++ b/integration_tests/redis/redis.py
@@ -46,6 +46,29 @@ class RedisClientTests(TestCase):
             mock.assert_called_once_with(client.connection, key, prefix)
 
 
+class FeatureInitializationTests(TestCase):
+    def setUp(self):
+        self.client = RedisClient(host='redis')
+        self.stream = self.client[self.id()]
+
+    def test_initial_state(self):
+        self.assertEqual(None, self.stream.last())
+
+    def test_append_to_initial_state(self):
+        self.stream.append({'foo': 'bar'})
+        self.assertEqual({'foo': 'bar'}, self.stream.last())
+
+    def test_len(self):
+        self.assertEqual(0, len(self.stream))
+
+    def test_iter(self):
+        for state in self.stream:
+            self.fail("Shouldn't have any items in the stream")
+
+    def test_first(self):
+        self.assertEqual(None, self.stream.first())
+
+
 class FeatureTests(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Fixes an error in get_current_state when no state has been written to redis yet

```
Sending message of length 9255 to http://localhost/api/1/store/
Internal Server Error: /admin/feats/features/api.current.features.NoopFeature/
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/web/src/aplaceforrover/common/handlers/wsgi.py", line 82, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/generic/base.py", line 155, in get
    context = self.get_context_data(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/feats/django/views/detail.py", line 14, in get_context_data
    state = feature.get_current_state()
  File "/usr/local/lib/python3.6/site-packages/feats/app.py", line 52, in get_current_state
    state_data = states.last()
  File "/usr/local/lib/python3.6/site-packages/feats/redis.py", line 80, in last
    info = self.info()
  File "/usr/local/lib/python3.6/site-packages/feats/redis.py", line 61, in info
    return self._redis.xinfo_stream(self.key)
  File "/usr/local/lib/python3.6/site-packages/redis/client.py", line 2062, in xinfo_stream
    return self.execute_command('XINFO STREAM', name)
  File "/usr/local/lib/python3.6/site-packages/redis/client.py", line 755, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "/usr/local/lib/python3.6/site-packages/redis/client.py", line 768, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 638, in read_response
    raise response
redis.exceptions.ResponseError: no such key
```