### PR TITLE
Add ability to "peek" at the selected implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,15 +205,17 @@ to use, without actually marking a user as "bucketed" for experiments. The clien
 that the client has used that implementation to persist that data. This removes the network latency required to display a feature
 at the cost of some additional latency between the time a feature is updated and the client sees that update.
 
-In order to do this, we can combine the Application's `peek_implementations` method to preselect implementations, alongside an individual Feature's
+In order to do this, we can combine the Feature's `find_implementation` method to preselect implementations, alongside that Feature's
 `used_implementation` method to notify that the client has used a certain implementation.
 
+For Features using an experiment, `find_implementation` will return a random implementation until that user has used an implementation. Calling a feature's `create` or `is_enabled` method will mark that user as having used the implementation returned.
+
 ```python
-implementations: Dict[str, str] = app.peek_implementations(user) # Returns mapping from name of feature to name of implementation
+impl_name = MyFeature.find_implementation(user) # Returns mapping from name of feature to name of implementation
 ```
 
 ```python
-app.features[name].used_implementation(impl_name, user)
+MyFeature.used_implementation(impl_name, user)
 ```
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -198,6 +198,24 @@ class ConfirmText:
         return "Persist"
 ```
 
+## Preselecting Implementations
+
+When dealing with client-side applications, it can be beneficial for the client to poll ahead-of-time the implementation
+to use, without actually marking a user as "bucketed" for experiments. The client can then asyncronously notify the server
+that the client has used that implementation to persist that data. This removes the network latency required to display a feature
+at the cost of some additional latency between the time a feature is updated and the client sees that update.
+
+In order to do this, we can combine the Application's `peek_implementations` method to preselect implementations, alongside an individual Feature's
+`used_implementation` method to notify that the client has used a certain implementation.
+
+```python
+implementations: Dict[str, str] = app.peek_implementations(user) # Returns mapping from name of feature to name of implementation
+```
+
+```python
+app.features[name].used_implementation(impl_name, user)
+```
+
 # Configuration
 
 # Examples

--- a/feats/app.py
+++ b/feats/app.py
@@ -141,7 +141,7 @@ class App:
         Returns the registered features which require values of the given input types.
         """
         return [
-                handle for handle in self.features
+                handle for handle in self.features.values()
                 if handle.feature.input_types == input_types
         ]
 

--- a/feats/app.py
+++ b/feats/app.py
@@ -20,10 +20,9 @@ class FeatureHandle:
 
     def find_selector(self, *args) -> Selector:
         state = self.state
-        if state is not None:
-            selector = state.find_selector(*args)
-            return selector
-        return Default(self.feature)
+        if state is None:
+            return Default(self.feature)
+        return state.find_selector(*args)
 
     def find_implementation(self, *args) -> str:
         """

--- a/feats/app.py
+++ b/feats/app.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Dict
+from typing import Dict, List, Optional, Type
 import copy
 
 from .storage import Storage
@@ -8,7 +8,7 @@ from .feature import Feature
 from .feature import default
 from .meta import Definition
 from .segment import Segment
-from .selector import Experiment, Rollout, Selector, Static
+from .selector import Experiment, Rollout, Selector, Static, Default
 from .state import FeatureState
 
 
@@ -46,7 +46,8 @@ class FeatureHandle:
         serialized_state = copy.deepcopy(new_state.serialize(self.app))
         self.app.storage[self.name].append(serialized_state)
 
-    def get_current_state(self) -> FeatureState:
+    @property
+    def state(self) -> Optional[FeatureState]:
         states = self.app.storage[self.name]
         try:
             state_data = states.last()
@@ -54,6 +55,11 @@ class FeatureHandle:
             return None
 
         return FeatureState.deserialize(self.app, state_data)
+
+    @state.setter
+    def state(self, new_state: FeatureState):
+        serialized_state = copy.deepcopy(new_state.serialize(self.app))
+        self.app.storage[self.name].append(serialized_state)
 
     def valid_segments(self):
         """
@@ -71,6 +77,28 @@ class FeatureHandle:
             if impl is not None:
                 found[name] = segment
         return found
+
+
+class FeatureFactory(FeatureHandle):
+    def create(self, *args) -> object:
+        """
+        Returns the appropriate implementation to use for the argument(s).
+
+        The implementation is found using any configured segmentations and
+        selectors for the feature.
+        """
+        selector = self.find_selector(*args)
+        name = selector.select(*args)
+        selector.used_implementation(name, *args)
+        return self.feature.implementations[name].fn(*args)
+
+
+class FeatureConditional(FeatureHandle):
+    def is_enabled(self, *args) -> bool:
+        selector = self.find_selector(*args)
+        name = selector.select(*args)
+        selector.used_implementation(name, *args)
+        return bool(self.feature.implementations[name].fn(*args))
 
 
 class App:
@@ -156,7 +184,7 @@ class App:
         definition = Definition.from_object(obj)
         feature = Feature(definition)
         name = self._name(cls)
-        handle = FeatureHandle(self, name, feature)
+        handle = FeatureFactory(self, name, feature)
         # TODO: Prevent double-write
         self.features[name] = handle
         return handle
@@ -168,22 +196,23 @@ class App:
         """
         return default(fn)
 
-    def boolean(self, fn):
+    def boolean(self, fn) -> FeatureConditional:
         """
-        Similar to `feature` but operates on a function. Initializes the
+        Similar to `feature` but operates on a boolean function.
         wrapped function and returns a handle to the registered boolean
         feature.
-
-        The handle has a method, create, which can be invoked to obtain an
-        implementation to use.
 
         Example:
         @my_app.boolean
         def MyFeature() -> bool:
             return True
 
-        This function will be automatically annotated as the default
-        implementation.
+        # Defaults to returning True
+        MyFeature.is_enabled()
+
+        This function will be automatically annotated as the default value,
+        and can be configured to either return True, False or the default value.
+
         """
         if not callable(fn):
             raise ValueError("Boolean feature must be a function")
@@ -192,13 +221,11 @@ class App:
         if return_type != bool:
             raise ValueError(f"Expected bool return type - got {return_type}")
 
-        fn = self.default(fn)
         definition = Definition.from_function(fn)
         feature = Feature(definition)
         name = self._name(fn)
-        handle = FeatureHandle(self, name, feature)
+        handle = FeatureConditional(self, name, feature)
         self.features[name] = handle
-
         return handle
 
     def segment(self, cls):

--- a/feats/app.py
+++ b/feats/app.py
@@ -189,7 +189,7 @@ class App:
     def boolean(self, fn) -> FeatureConditional:
         """
         Similar to `feature` but operates on a boolean function.
-        wrapped function and returns a handle to the registered boolean
+        Wraps the function and returns a handle to the registered boolean
         feature.
 
         Example:

--- a/feats/django/apps.py
+++ b/feats/django/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured, AppRegistryNotReady
 from django.conf import settings
 from feats import App
+from importlib import import_module
 
 
 class FeatsConfig(AppConfig):
@@ -24,6 +25,13 @@ class FeatsConfig(AppConfig):
                 type(feats_app)
             )
         self._feats_app = feats_app
+        # Register other feats files in other django apps
+        for app in self.apps.get_app_configs():
+            try:
+                import_module('.feats', app.name)
+            except ModuleNotFoundError:
+                # Not all apps need to have feats
+                pass
 
     @property
     def feats_app(self):

--- a/feats/django/templates/feats/selectors/_experiment.html
+++ b/feats/django/templates/feats/selectors/_experiment.html
@@ -1,5 +1,3 @@
-Segmentation: {{ selector.segment }}
-
 <table class="table">
     <thead>
         <tr>

--- a/feats/django/views/detail.py
+++ b/feats/django/views/detail.py
@@ -11,7 +11,7 @@ class Detail(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         feature = self.feature
-        state = feature.get_current_state()
+        state = feature.state
         context['feature'] = feature
         context['state'] = state
         if state:

--- a/feats/django/views/segmentation.py
+++ b/feats/django/views/segmentation.py
@@ -145,14 +145,10 @@ class ChangeMapping(base.TemplateView):
     def get_context_data(self):
         context = super().get_context_data()
         feature = self.feature
-        state = feature.get_current_state()
+        state = feature.state
         if state is None:
-            state = FeatureState(
-                segments=[],
-                selectors=[],
-                selector_mapping={},
-                created_by=self.request.user.username
-            )
+            state = FeatureState.initial(self.request.user.username)
+
         segments = self.get_segment_formset(feature).validate_and_get_segments(self.feats_app)
         context['feature'] = feature
         context['segment_names'] = [segment.name for segment in segments]
@@ -161,15 +157,11 @@ class ChangeMapping(base.TemplateView):
 
     def post(self, request, *args, **kwargs):
         feature = self.feature
-        state = feature.get_current_state()
+        state = feature.state
         segments = self.get_segment_formset(feature).validate_and_get_segments(self.feats_app)
         if state is None:
-            state = FeatureState(
-                    segments=[],
-                    selectors=[],
-                    selector_mapping={},
-                    created_by=self.request.user.username
-            )
+            state = FeatureState.initial(self.request.user.username)
+
         mapping_formset = self.get_mapping_formset(segments, state, request.POST)
         if mapping_formset.is_valid():
             selector_mapping = dict(
@@ -181,7 +173,7 @@ class ChangeMapping(base.TemplateView):
                     selector_mapping=selector_mapping,
                     created_by=self.request.user.username
             )
-            self.feature.set_state(state)
+            self.feature.state = state
             return HttpResponseRedirect(
                 reverse('feats:detail', args=self.args)
             )
@@ -215,13 +207,10 @@ class ChangeSegmentation(base.TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         feature = self.feature
-        state = feature.get_current_state()
+        state = feature.state
         if state is None:
-            state = FeatureState(
-                    segments=[],
-                    selectors=[],
-                    selector_mapping={},
-                    created_by=self.request.user.username
+            state = FeatureState.initial(
+                    self.request.user.username
             )
         segment_formset = self.get_formset(feature, state)
         context['formset'] = segment_formset

--- a/feats/django/views/selectors.py
+++ b/feats/django/views/selectors.py
@@ -105,20 +105,9 @@ class RolloutSelectorForm(WeightedSelectorForm):
 
 class ExperimentSelectorForm(WeightedSelectorForm):
     def __init__(self, feature_handle, selector=None, initial=None, *args, **kwargs):
-        if selector is not None:
-            initial = initial or {}
-            initial['segment'] = selector.segment.name
-
         super().__init__(feature_handle, 'experiment', selector, initial, *args, **kwargs)
-        self.fields['segment'] = base.ChoiceField(
-            choices=[
-                (name, name) for name in feature_handle.valid_segments().keys()
-            ],
-            required=True,
-        )
 
     def create_selector(self):
-        segment = self.cleaned_data['segment']
         name = self.cleaned_data['name']
         weights = self.get_weights()
 
@@ -128,7 +117,6 @@ class ExperimentSelectorForm(WeightedSelectorForm):
                 # Needs App support for registering persisters
                 'persister': "# TODO:",
                 'weights': weights,
-                'segment': segment
             }
         )
 

--- a/feats/meta.py
+++ b/feats/meta.py
@@ -73,11 +73,9 @@ class Definition:
             fn(*args, **kwargs)
             return False
 
-        annotations = defaultdict(list)
         default = Implementation(Default)
-        if hasattr(fn, '_feats_annotations_'):
-            for annotation in fn._feats_annotations_:
-                annotations[annotation].append(default)
+        annotations = defaultdict(list)
+        annotations['default'] = [default]
 
         implementations = [
             Implementation(Enabled),

--- a/feats/selector.py
+++ b/feats/selector.py
@@ -49,6 +49,10 @@ class Selector(metaclass=abc.ABCMeta):
 
 class Default(Selector):
     """
+    Picks the default implementation of the feature.
+
+    Used to represent the case where no FeatureState exists, and
+    so will never be persisted to storage or configured by a user.
     """
     def __init__(self, feature):
         super().__init__("Default")

--- a/feats/selector.py
+++ b/feats/selector.py
@@ -193,19 +193,16 @@ class Experiment(Selector):
     def __init__(
             self,
             name: str,
-            segment: Segment,
             persister: ExperimentPersister,
             weights: Weights
     ):
         super().__init__(name)
-        self.segment = segment
         self.persister = persister
         self.population = list(weights.keys())
         self.weights = list(weights.values())
 
     def select(self, value: object) -> str:
-        key = self.segment.segment(value)
-        existing_group = self.persister.get_existing_test_group(key)
+        existing_group = self.persister.get_existing_test_group(value)
         if existing_group is not None:
             return existing_group
 
@@ -219,7 +216,6 @@ class Experiment(Selector):
     def from_data(cls, app, configuration):
         return cls(
             name=configuration['name'],
-            segment=app.get_segment(configuration['segment']),
             persister=app.get_persister(configuration['persister']),
             weights=configuration['weights'],
         )
@@ -227,7 +223,6 @@ class Experiment(Selector):
     def serialize_data(self, app):
         return {
             'name': self.name,
-            'segment': self.segment.name,
             'persister': app._name(self.persister),
             'weights': self.weights,
         }

--- a/feats/state.py
+++ b/feats/state.py
@@ -34,7 +34,7 @@ class FeatureState:
                 raise ValueError(f"{selector.name} was mapped, but not included in the set of selectors for this feature")
 
     def find_selector(self, *args) -> Optional[Selector]:
-        segment_values = tuple([segment(*args) for segment in self.segments])
+        segment_values = tuple([segment.segment(*args) for segment in self.segments])
         return self.selector_mapping.get(segment_values, self.selector_mapping.get(None))
 
     def add_selector(self, selector: Selector, created_by: str) -> 'FeatureState':

--- a/tests/feats/feature.py
+++ b/tests/feats/feature.py
@@ -217,7 +217,7 @@ def InvalidBooleanFeatureNoInputType(arg) -> bool:
     return True
 
 
-class AppTests(TestCase):
+class AppDefinitionTests(TestCase):
     def setUp(self):
         super().setUp()
         self.app = App(storage=Memory())
@@ -299,9 +299,23 @@ class AppTests(TestCase):
             with self.subTest(fn), self.assertRaises(ValueError):
                 self.app.boolean(fn)
 
-    def test_used_implementation(self):
-        feature = self.app.boolean(ValidBooleanFeature)
-        with self.subTest("no state"):
-            feature.used_implementation("True")
 
+class GetApplicableFeaturesTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.app = App(storage=Memory())
 
+    def test_no_applicable_features(self):
+        with self.subTest("No Registered Features"):
+            self.assertEqual([], self.app.get_applicable_features([int]))
+
+        with self.subTest("Registered Features"):
+            self.app.feature(ValidUnaryFeatures.One)
+            self.assertEqual([], self.app.get_applicable_features([int]))
+
+    def test_applicable_features(self):
+        one = self.app.feature(ValidUnaryFeatures.One)
+        two = self.app.feature(ValidUnaryFeatures.Two)
+        three = self.app.feature(ValidUnaryFeatures.Three)
+
+        self.assertEqual([one, two, three], self.app.get_applicable_features([str]))

--- a/tests/feats/feature.py
+++ b/tests/feats/feature.py
@@ -3,6 +3,8 @@ from unittest import TestCase
 import feats
 from feats.app import App
 from feats.storage import Memory
+from feats.selector import Static
+from feats.state import FeatureState
 
 
 class InvalidUnaryFeatures:
@@ -199,6 +201,10 @@ def ValidBooleanFeature() -> bool:
     return True
 
 
+def ValidUnaryBooleanFeature(arg: str) -> bool:
+    return False
+
+
 def InvalidBooleanFeatureNoReturnType():
     return True
 
@@ -280,7 +286,7 @@ class AppTests(TestCase):
             self.assertEqual(default[0].fn(), fn())
 
         with self.subTest("handle"):
-            self.assertEqual(handle.create(), True)
+            self.assertTrue(handle.is_enabled())
 
     def test_invalid_boolean_features(self):
         fns = [

--- a/tests/feats/feature.py
+++ b/tests/feats/feature.py
@@ -298,3 +298,10 @@ class AppTests(TestCase):
         for fn in fns:
             with self.subTest(fn), self.assertRaises(ValueError):
                 self.app.boolean(fn)
+
+    def test_used_implementation(self):
+        feature = self.app.boolean(ValidBooleanFeature)
+        with self.subTest("no state"):
+            feature.used_implementation("True")
+
+

--- a/tests/feats/state.py
+++ b/tests/feats/state.py
@@ -1,12 +1,145 @@
 import json
 
 from unittest import TestCase
+from collections import namedtuple
 
 import feats.errors as errors
 from feats.app import App
 from feats.selector import Rollout
+from feats.selector import Static
 from feats.storage import Memory
 from feats.state import FeatureState
+
+
+class FeatureStateBuilderTests(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.initial = FeatureState.initial('sentinel')
+
+    def test_initial(self):
+        self.assertEqual([], self.initial.segments)
+        self.assertEqual([], self.initial.selectors)
+        self.assertEqual({}, self.initial.selector_mapping)
+        self.assertEqual('sentinel', self.initial.created_by)
+
+    def test_add_selector(self):
+        selector = Static('new_selector', 'sentinel')
+        other_selector = Static('other_selector', 'sentinel')
+        tests = [
+            (self.initial, [selector]),
+            (FeatureState(
+                segments=[],
+                selectors=[other_selector],
+                selector_mapping={None: other_selector},
+                created_by='test'
+            ),
+            [other_selector, selector]),
+        ]
+
+        for initial, expected in tests:
+            with self.subTest():
+                new_state = initial.add_selector(selector, 'test')
+                self.assertEqual(new_state.selectors, expected)
+                self.assertEqual(new_state.selector_mapping, initial.selector_mapping)
+                self.assertEqual(new_state.segments, initial.segments)
+                self.assertEqual(new_state.created_by, 'test')
+
+    def test_remove_selector(self):
+        selector_to_remove = Static('to_remove', 'sentinel')
+        other_selector = Static('other_selector', 'other')
+
+        tests = [
+                (
+                    [selector_to_remove],
+                    {},
+                    0,
+                    [],
+                    {},
+                ),
+                (
+                    [selector_to_remove],
+                    {None: selector_to_remove},
+                    0,
+                    [],
+                    {}
+                ),
+                (
+                    [other_selector, selector_to_remove],
+                    {None: other_selector},
+                    1,
+                    [other_selector],
+                    {None: other_selector},
+                ),
+                (
+                    [other_selector, selector_to_remove],
+                    {None: other_selector},
+                    1,
+                    [other_selector],
+                    {None: other_selector},
+                )
+        ]
+        for initial_selector, initial_map, index, expected_selectors, expected_map in tests:
+            with self.subTest():
+                initial_state = FeatureState(
+                        segments=[],
+                        selectors=initial_selector.copy(),
+                        selector_mapping=initial_map.copy(),
+                        created_by='test'
+                )
+                new_state = initial_state.remove_selector(index, 'test2')
+                self.assertEqual(new_state.segments, [])
+                self.assertEqual(new_state.selectors, expected_selectors)
+                self.assertEqual(new_state.selector_mapping, expected_map)
+                self.assertEqual(new_state.created_by, 'test2')
+
+    def test_update_selector(self):
+        selector_to_update = Static('to_update', 'sentinel')
+        updated_selector = Static('updated_selector', 'updated')
+        other_selector = Static('other_selector', 'other')
+        tests = [
+                (
+                    [selector_to_update],
+                    {},
+                    0,
+                    [updated_selector],
+                    {},
+                ),
+                (
+                    [selector_to_update],
+                    {None: selector_to_update},
+                    0,
+                    [updated_selector],
+                    {None: updated_selector}
+                ),
+                (
+                    [other_selector, selector_to_update],
+                    {None: other_selector},
+                    1,
+                    [other_selector, updated_selector],
+                    {None: other_selector},
+                ),
+                (
+                    [other_selector, selector_to_update],
+                    {None: other_selector, ('a',): selector_to_update, ('b',): selector_to_update},
+                    1,
+                    [other_selector, updated_selector],
+                    {None: other_selector, ('a',): updated_selector, ('b',): updated_selector},
+                )
+        ]
+        for initial_selector, initial_map, index, expected_selectors, expected_map in tests:
+            with self.subTest():
+                initial_state = FeatureState(
+                        segments=[],
+                        selectors=initial_selector.copy(),
+                        selector_mapping=initial_map.copy(),
+                        created_by='test'
+                )
+                new_state = initial_state.update_selector(index, updated_selector, 'test2')
+                self.assertEqual(new_state.segments, [])
+                self.assertEqual(new_state.selectors, expected_selectors)
+                self.assertEqual(new_state.selector_mapping, expected_map)
+                self.assertEqual(new_state.created_by, 'test2')
 
 
 class SerializeStateTests(TestCase):


### PR DESCRIPTION
* Adds the ability for feats to serve client side applications by returning a selected implementation, without actually persisting that implementation until the client has used it.
* Updates FeatureState with some create/update/delete selector methods that are easier to test than a Django View. Also fixes an issue w/not being able to update a selector after it has been mapped.
* Removes segmentation from experiment, as it wasn't necessary (the persister takes care of any conversions). This isn't necessary for this PR, but is setup for the next PR about experiment persistence.
* Updates the django app to auto-import all registered apps `feats.py` files. This lessens the likelihood we have a feature or a segment registered once the server is completely initialized.