### PR TITLE
Allow segments to be scoped to specified options

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,26 @@ class Subdivision:
         return "{}-{}".format(address.country_code, address.subdivision_code)
 ```
 
+It is also possible to designate specific options for a segment. If, for
+example, we wished to create a segment on device type and we knew the two
+options we cared about were `"android"` and `"ios"`, we could create the
+following segment:
+
+```python
+@app.segment
+class UserDevice:
+    """
+    The user device data from the Request, e.g "ios"
+    """
+    OPTIONS = ['ios', 'android']
+
+    def request(self, request: Request) -> str:
+        return request['device']
+```
+
+This allows us to select from that list of `OPTIONS` when we define how this
+segment should be routed to feature implementations.
+
 
 ## Feature Inputs
 

--- a/feats/app.py
+++ b/feats/app.py
@@ -239,6 +239,6 @@ class App:
         obj = cls()
         name = self._name(cls)
         definition = Definition.from_object(obj)
-        seg = Segment(name, definition)
+        seg = Segment(name, definition, options=getattr(obj, 'OPTIONS', None))
         self.segments[name] = seg
         return seg

--- a/feats/django/views/segmentation.py
+++ b/feats/django/views/segmentation.py
@@ -115,7 +115,17 @@ class SelectorMappingForm(base.Form):
                 required=True
         )
         for segment in segments:
-            self.fields['segment[{}]'.format(segment.name)] = base.CharField(required=True)
+            field = base.CharField(required=True)
+
+            if segment.options is not None:
+                field = base.ChoiceField(
+                    choices=[
+                        (i, opt) for i, opt in enumerate(segment.options)
+                    ],
+                    required=True
+                )
+
+            self.fields['segment[{}]'.format(segment.name)] = field
 
     def get_mapping_entry(self):
         """

--- a/feats/segment.py
+++ b/feats/segment.py
@@ -1,15 +1,17 @@
 from functools import lru_cache
 from inspect import getmro
+from typing import List
 
 from .meta import Definition, Implementation
 
 
 class Segment:
-    def __init__(self, name: str, definition: Definition):
+    def __init__(self, name: str, definition: Definition, options: List[str]=None):
         _check_output_type(definition)
         _check_input_type(definition)
         self.name = name
         self.definition = definition
+        self.options = options
         self.input_mapping = {
             impl.input_types[0]: impl
             for impl in self.definition.implementations.values()

--- a/tests/feats/feature.py
+++ b/tests/feats/feature.py
@@ -190,6 +190,12 @@ class InvalidSegments:
         def reticulate_string(self, value: str) -> int:
             return 0
 
+class OptionsSegment:
+    OPTIONS = ['foo', 'bar']
+
+    def reticulate_string(self, value: str) -> str:
+        return "reticulated string"
+
 
 class InvalidBooleanFeatureAsClass:
     @feats.default
@@ -273,6 +279,10 @@ class AppDefinitionTests(TestCase):
     def test_segments_must_be_class(self):
         with self.assertRaises(ValueError):
             self.app.segment(ValidBooleanFeature)
+
+    def test_segment_with_options(self):
+        segment = self.app.segment(OptionsSegment)
+        self.assertEqual(segment.options, ['foo', 'bar'])
 
     def test_valid_boolean_feature(self):
         fn = ValidBooleanFeature


### PR DESCRIPTION
Allows a segment to be defined with a preset list of options. This may
be useful when targeting a small, known set of values for specific
segments (device types, country codes, etc.)

The initial plan was to allow this to be specified in the decorator
(`@segment(options=[...])`), however this is currently not possible
without a larger refactor of our approach to defining these decorators.
This implementation works fundamentally the same way, but with options
defined as a class level constant.